### PR TITLE
Set iOS status bar background to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@serbis_tech" />
     <meta name="twitter:image" content="/public/lovable-uploads/9a63b71d-a687-4f28-97c2-dfa5cb7bef35.png" />
+
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,9 @@
   * {
     @apply border-border;
   }
+  html {
+    background-color: #ffffff;
+  }
   body {
     @apply bg-background text-foreground;
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
## Summary
- set the mobile browser theme color meta tag to white so iOS renders the status bar background without a dark strip
- explicitly paint the html element white to ensure the safe area above the page matches the rest of the layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95bde60408329a95a0396064ad947