### PR TITLE
Adjust mobile header safe area and favicon visibility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -127,4 +127,13 @@
   .animate-slide-up-fade {
     animation: slide-up-fade 0.8s ease-out forwards;
   }
+
+  .safe-area-padding {
+    padding-top: env(safe-area-inset-top);
+    padding-top: constant(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-left: constant(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    padding-right: constant(safe-area-inset-right);
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,17 +68,19 @@ const Index = () => {
   return (
     <div className="bg-white text-gray-900 min-h-screen">
       {/* Navigation */}
-      <nav className={`fixed w-full top-0 z-50 transition-all duration-500 ${
-        scrolled 
-          ? 'bg-white/80 backdrop-blur-2xl border-b border-gray-100' 
-          : 'bg-transparent'
-      }`}>
+      <nav
+        className={`safe-area-padding fixed w-full top-0 z-50 transition-all duration-500 ${
+          scrolled
+            ? 'bg-white/80 backdrop-blur-2xl border-b border-gray-100'
+            : 'bg-white/80 backdrop-blur-2xl border-b border-transparent md:bg-transparent md:backdrop-blur-0'
+        }`}
+      >
         <div className="max-w-6xl mx-auto px-6 lg:px-8">
-          <div className="flex justify-between items-center h-20">
-            <div className="flex items-center -ml-20">
-              <img 
-                src="/favicon.ico" 
-                alt="Serbis" 
+          <div className="flex justify-between items-center py-5">
+            <div className="flex items-center md:-ml-20">
+              <img
+                src="/favicon.ico"
+                alt="Serbis"
                 className="w-10 h-10"
               />
             </div>


### PR DESCRIPTION
## Summary
- add a reusable safe-area padding utility to apply iOS safe area insets
- update the fixed header to use the safe-area padding and default mobile background to eliminate the black bar
- remove the negative margin on small screens so the favicon remains visible in the mobile header

## Testing
- npm run lint *(fails: existing lint errors in shared UI components and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68cda3b2a910832989740f563904b374